### PR TITLE
improve build instructions in README

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,17 @@ Then install it:
 
     % make install
 
+Note that manual installation requires the following modules before you can
+run the above `perl Makefile.PL` command:
+
+    * Module::Install
+    * Module::Install::AuthorTests
+    * Module::Install::Repository
+
+
+You will then need to install other prerequisites listed by `perl Makefile.PL`
+to complete the build.
+
 DOCUMENTATION
 
 MouseX::Types documentation is available as in POD. So you can do:


### PR DESCRIPTION
because this dist depends on the none core Module::Install you must
install this (and other modules) before you can even run the perl
Makefile.PL command, so list those requirements in the README and
point out that they are required
