### PR TITLE
fix perlcritic test for use of "no strict"

### DIFF
--- a/lib/MouseX/Types.pm
+++ b/lib/MouseX/Types.pm
@@ -39,7 +39,7 @@ sub import {
                  return $fq_name;
             };
 
-            no strict;
+            no strict; ## no critic
             *{$fq_name} = $type;
         }
     }


### PR DESCRIPTION
in lib/MouseX/Types.pm - which disables strict so add the comment
"## no critic" so fix test failure here. we could add no strict to
the perlcritic policy, but that would be silly
