### PR TITLE
remove TODOs that are passing in tests

### DIFF
--- a/t/100-compat/10_moose-types.t
+++ b/t/100-compat/10_moose-types.t
@@ -19,7 +19,6 @@ for my $t (@types) {
     else {
         diag "Skipping $t() call test";
     }
-    local $TODO = 'is_T is not supported by MouseX::Types';
     ok __PACKAGE__->can("is_$t"), "is_$t() was exported";
 }
 

--- a/t/101-100_with_Any-Moose/10_moose-types.t
+++ b/t/101-100_with_Any-Moose/10_moose-types.t
@@ -19,6 +19,5 @@ for my $t (@types) {
     else {
         diag "Skipping $t() call test";
     }
-    local $TODO = 'is_T is not supported by MouseX::Types';
     ok __PACKAGE__->can("is_$t"), "is_$t() was exported";
 }


### PR DESCRIPTION
tests for is_\* are passing, so these TODOs can be removed since we
can do what we think we can't do, they're no longer TODOs
